### PR TITLE
Aroma port to WUPS 0.9.1, add KPADRead/KPADReadEx hooks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM wiiuenv/devkitppc:20200810
+FROM ghcr.io/wiiu-env/devkitppc:20260504
 
-COPY --from=wiiuenv/wiiupluginsystem:20200829 /artifacts $DEVKITPRO
-COPY --from=wiiuenv/controller_patcher:20201216 /artifacts $DEVKITPRO
+COPY --from=ghcr.io/wiiu-env/wiiupluginsystem:20260503 /artifacts $DEVKITPRO
+COPY --from=ghcr.io/wiiu-env/controller_patcher:latest /artifacts $DEVKITPRO
 
 WORKDIR project

--- a/src/ConfigHooks.cpp
+++ b/src/ConfigHooks.cpp
@@ -22,57 +22,47 @@
 #include <coreinit/debug.h>
 #include <wups.h>
 #include <wups/config/WUPSConfigItemBoolean.h>
+#include <wups/config_api.h>
+#include <wups/storage.h>
 
 bool runNetworkClient = true;
-
 
 void loadMapping(const std::string &persistedValue, UController_Type type);
 
 void ConfigLoad() {
-    WUPS_OpenStorage();
-
     bool rumble = false;
+    WUPSStorageAPI::GetOrStoreDefault("rumble", rumble, false);
+    DEBUG_FUNCTION_LINE("Set rumble to %d", rumble);
+    ControllerPatcher::setRumbleActivated(rumble);
 
-    if (WUPS_GetBool(nullptr, "rumble", &rumble) == WUPS_STORAGE_ERROR_SUCCESS) {
-        DEBUG_FUNCTION_LINE("Set rumble to %d", rumble);
-        ControllerPatcher::setRumbleActivated(rumble);
-    } else {
-        WUPS_StoreBool(nullptr, "rumble", ControllerPatcher::isRumbleActivated());
-    }
-
-    if (WUPS_GetBool(nullptr, "networkclient", &runNetworkClient) != WUPS_STORAGE_ERROR_SUCCESS) {
-        WUPS_StoreBool(nullptr, "networkclient", runNetworkClient);
-    }
+    WUPSStorageAPI::GetOrStoreDefault("networkclient", runNetworkClient, true);
 
     char buffer[512];
-    if (WUPS_GetString(nullptr, "gamepadmapping", buffer, sizeof(buffer)) == WUPS_STORAGE_ERROR_SUCCESS) {
-        std::string stringWrapper = buffer;
-        loadMapping(stringWrapper, UController_Type_Gamepad);
-    }
 
-    if (WUPS_GetString(nullptr, "pro1", buffer, sizeof(buffer)) == WUPS_STORAGE_ERROR_SUCCESS) {
-        std::string stringWrapper = buffer;
-        loadMapping(stringWrapper, UController_Type_Pro1);
+    buffer[0] = '\0';
+    if (WUPSStorageAPI_GetString(nullptr, "gamepadmapping", buffer, sizeof(buffer), nullptr) == WUPS_STORAGE_ERROR_SUCCESS && buffer[0] != '\0') {
+        loadMapping(std::string(buffer), UController_Type_Gamepad);
     }
-    if (WUPS_GetString(nullptr, "pro2", buffer, sizeof(buffer)) == WUPS_STORAGE_ERROR_SUCCESS) {
-        std::string stringWrapper = buffer;
-        loadMapping(stringWrapper, UController_Type_Pro2);
+    buffer[0] = '\0';
+    if (WUPSStorageAPI_GetString(nullptr, "pro1", buffer, sizeof(buffer), nullptr) == WUPS_STORAGE_ERROR_SUCCESS && buffer[0] != '\0') {
+        loadMapping(std::string(buffer), UController_Type_Pro1);
     }
-    if (WUPS_GetString(nullptr, "pro3", buffer, sizeof(buffer)) == WUPS_STORAGE_ERROR_SUCCESS) {
-        std::string stringWrapper = buffer;
-        loadMapping(stringWrapper, UController_Type_Pro3);
+    buffer[0] = '\0';
+    if (WUPSStorageAPI_GetString(nullptr, "pro2", buffer, sizeof(buffer), nullptr) == WUPS_STORAGE_ERROR_SUCCESS && buffer[0] != '\0') {
+        loadMapping(std::string(buffer), UController_Type_Pro2);
     }
-    if (WUPS_GetString(nullptr, "pro4", buffer, sizeof(buffer)) == WUPS_STORAGE_ERROR_SUCCESS) {
-        std::string stringWrapper = buffer;
-        loadMapping(stringWrapper, UController_Type_Pro4);
+    buffer[0] = '\0';
+    if (WUPSStorageAPI_GetString(nullptr, "pro3", buffer, sizeof(buffer), nullptr) == WUPS_STORAGE_ERROR_SUCCESS && buffer[0] != '\0') {
+        loadMapping(std::string(buffer), UController_Type_Pro3);
     }
-
-    WUPS_CloseStorage();
+    buffer[0] = '\0';
+    if (WUPSStorageAPI_GetString(nullptr, "pro4", buffer, sizeof(buffer), nullptr) == WUPS_STORAGE_ERROR_SUCCESS && buffer[0] != '\0') {
+        loadMapping(std::string(buffer), UController_Type_Pro4);
+    }
 }
 
 void loadMapping(const std::string &persistedValue, UController_Type controllerType) {
     if (persistedValue.empty()) {
-        // No device mapped.
         return;
     }
     std::vector<std::string> result = StringTools::stringSplit(persistedValue, ",");
@@ -84,74 +74,92 @@ void loadMapping(const std::string &persistedValue, UController_Type controllerT
     mappedPadInfo.vidpid.vid = atoi(result.at(0).c_str());
     mappedPadInfo.vidpid.pid = atoi(result.at(1).c_str());
     mappedPadInfo.pad        = atoi(result.at(2).c_str());
-    mappedPadInfo.type       = CM_Type_Controller; //atoi(result.at(3).c_str());
+    mappedPadInfo.type       = CM_Type_Controller;
 
     ControllerPatcher::addControllerMapping(controllerType, mappedPadInfo);
 }
 
 void rumbleChanged(ConfigItemBoolean *item, bool newValue) {
-    DEBUG_FUNCTION_LINE("rumbleChanged %d ", newValue);
+    DEBUG_FUNCTION_LINE("rumbleChanged %d", newValue);
     ControllerPatcher::setRumbleActivated(newValue);
-    WUPS_StoreInt(nullptr, "rumble", newValue);
+    WUPSStorageAPI::Store("rumble", newValue);
 }
 
 void networkClientChanged(ConfigItemBoolean *item, bool newValue) {
     DEBUG_FUNCTION_LINE("Trigger network %d", newValue);
+    runNetworkClient = newValue;
     ControllerPatcher::setNetworkControllerActivated(newValue);
     if (newValue) {
         ControllerPatcher::startNetworkServer();
     } else {
         ControllerPatcher::stopNetworkServer();
     }
-    WUPS_StoreInt(nullptr, "networkclient", newValue);
+    WUPSStorageAPI::Store("networkclient", newValue);
 }
 
 void PadMappingUpdated(ConfigItemPadMapping *item) {
     ControllerPatcher::resetControllerMapping(item->controllerType);
     if (item->mappedPadInfo.active && item->mappedPadInfo.type == CM_Type_Controller) {
         auto res = StringTools::strfmt("%d,%d,%d,%d", item->mappedPadInfo.vidpid.vid, item->mappedPadInfo.vidpid.pid, item->mappedPadInfo.pad, item->mappedPadInfo.type);
-        WUPS_StoreString(nullptr, item->configId, res.c_str());
+        WUPSStorageAPI_StoreString(nullptr, item->configId, res.c_str());
         loadMapping(res, item->controllerType);
         return;
     }
-    WUPS_StoreString(nullptr, item->configId, "");
+    WUPSStorageAPI_StoreString(nullptr, item->configId, "");
 }
 
 bool gConfigMenuOpen = false;
-WUPS_CONFIG_CLOSED() {
-    gConfigMenuOpen = false;
-    // Save all changes
-    if (WUPS_CloseStorage() != WUPS_STORAGE_ERROR_SUCCESS) {
-        OSReport("Failed to close storage\n");
-    }
-}
 
-#define CONFIG_PadMapping_AddToCategory(__config__, category, config_id, display_name, controller_type, callback) \
-    if (!WUPSConfigItemPadMapping_AddToCategory(category, config_id, display_name, controller_type, callback)) {  \
-        WUPSConfig_Destroy(__config__);                                                                           \
-        return 0;                                                                                                 \
-    }
-
-WUPS_GET_CONFIG() {
-    WUPS_OpenStorage();
+WUPSConfigAPICallbackStatus configMenuOpenedCallback(WUPSConfigCategoryHandle root) {
     gConfigMenuOpen = true;
-
-    WUPSConfigHandle config;
-    WUPSConfig_CreateHandled(&config, "HID to VPAD");
 
     WUPSConfigCategoryHandle catMapping;
     WUPSConfigCategoryHandle catOther;
 
-    WUPSConfig_AddCategoryByNameHandled(config, "Mapping", &catMapping);
-    WUPSConfig_AddCategoryByNameHandled(config, "Other", &catOther);
-    WUPSConfigItemBoolean_AddToCategoryHandledEx(config, catOther, "rumble", "Rumble", ControllerPatcher::isRumbleActivated(), &rumbleChanged, "On", "Off");
-    WUPSConfigItemBoolean_AddToCategoryHandledEx(config, catOther, "networkclient", "Network Client", runNetworkClient, &networkClientChanged, "On", "Off");
+    if (WUPSConfigAPI_Category_Create({.name = "Mapping"}, &catMapping) != WUPSCONFIG_API_RESULT_SUCCESS) {
+        DEBUG_FUNCTION_LINE("Failed to create Mapping category");
+        return WUPSCONFIG_API_CALLBACK_RESULT_ERROR;
+    }
+    if (WUPSConfigAPI_Category_Create({.name = "Other"}, &catOther) != WUPSCONFIG_API_RESULT_SUCCESS) {
+        DEBUG_FUNCTION_LINE("Failed to create Other category");
+        return WUPSCONFIG_API_CALLBACK_RESULT_ERROR;
+    }
 
-    CONFIG_PadMapping_AddToCategory(config, catMapping, "gamepadmapping", "Gamepad", UController_Type_Gamepad, &PadMappingUpdated);
-    CONFIG_PadMapping_AddToCategory(config, catMapping, "pro1", "Pro Controller 1", UController_Type_Pro1, &PadMappingUpdated);
-    CONFIG_PadMapping_AddToCategory(config, catMapping, "pro2", "Pro Controller 2", UController_Type_Pro2, &PadMappingUpdated);
-    CONFIG_PadMapping_AddToCategory(config, catMapping, "pro3", "Pro Controller 3", UController_Type_Pro3, &PadMappingUpdated);
-    CONFIG_PadMapping_AddToCategory(config, catMapping, "pro4", "Pro Controller 4", UController_Type_Pro4, &PadMappingUpdated);
+    if (WUPSConfigItemBoolean_AddToCategoryEx(catOther, "rumble", "Rumble",
+                                              false, ControllerPatcher::isRumbleActivated(),
+                                              &rumbleChanged, "On", "Off") != WUPSCONFIG_API_RESULT_SUCCESS) {
+        DEBUG_FUNCTION_LINE("Failed to add rumble item");
+        return WUPSCONFIG_API_CALLBACK_RESULT_ERROR;
+    }
+    if (WUPSConfigItemBoolean_AddToCategoryEx(catOther, "networkclient", "Network Client",
+                                              true, runNetworkClient,
+                                              &networkClientChanged, "On", "Off") != WUPSCONFIG_API_RESULT_SUCCESS) {
+        DEBUG_FUNCTION_LINE("Failed to add networkclient item");
+        return WUPSCONFIG_API_CALLBACK_RESULT_ERROR;
+    }
 
-    return config;
+    if (!WUPSConfigItemPadMapping_AddToCategory(catMapping, "gamepadmapping", "Gamepad", UController_Type_Gamepad, &PadMappingUpdated) ||
+        !WUPSConfigItemPadMapping_AddToCategory(catMapping, "pro1", "Pro Controller 1", UController_Type_Pro1, &PadMappingUpdated) ||
+        !WUPSConfigItemPadMapping_AddToCategory(catMapping, "pro2", "Pro Controller 2", UController_Type_Pro2, &PadMappingUpdated) ||
+        !WUPSConfigItemPadMapping_AddToCategory(catMapping, "pro3", "Pro Controller 3", UController_Type_Pro3, &PadMappingUpdated) ||
+        !WUPSConfigItemPadMapping_AddToCategory(catMapping, "pro4", "Pro Controller 4", UController_Type_Pro4, &PadMappingUpdated)) {
+        DEBUG_FUNCTION_LINE("Failed to add pad mapping item");
+        return WUPSCONFIG_API_CALLBACK_RESULT_ERROR;
+    }
+
+    if (WUPSConfigAPI_Category_AddCategory(root, catMapping) != WUPSCONFIG_API_RESULT_SUCCESS) {
+        DEBUG_FUNCTION_LINE("Failed to add Mapping category to root");
+        return WUPSCONFIG_API_CALLBACK_RESULT_ERROR;
+    }
+    if (WUPSConfigAPI_Category_AddCategory(root, catOther) != WUPSCONFIG_API_RESULT_SUCCESS) {
+        DEBUG_FUNCTION_LINE("Failed to add Other category to root");
+        return WUPSCONFIG_API_CALLBACK_RESULT_ERROR;
+    }
+
+    return WUPSCONFIG_API_CALLBACK_RESULT_SUCCESS;
+}
+
+void configMenuClosedCallback() {
+    gConfigMenuOpen = false;
+    WUPSStorageAPI::SaveStorage();
 }

--- a/src/FunctionPatches.cpp
+++ b/src/FunctionPatches.cpp
@@ -21,6 +21,7 @@
 #include <coreinit/cache.h>
 #include <coreinit/debug.h>
 #include <coreinit/thread.h>
+#include <padscore/kpad.h>
 
 extern bool gConfigMenuOpen;
 DECL_FUNCTION(int32_t, VPADRead, VPADChan chan, VPADStatus *buffer, uint32_t buffer_size, VPADReadError *error) {
@@ -180,6 +181,41 @@ DECL_FUNCTION(void, WPADRead, WPADChan chan, WPADStatusProController *data) {
     }
 }
 
+DECL_FUNCTION(int32_t, KPADRead, KPADChan chan, KPADStatus *data, uint32_t size) {
+    if (gConfigMenuOpen) {
+        return real_KPADRead(chan, data, size);
+    }
+    if (data != nullptr && size > 0 &&
+        ((chan == WPAD_CHAN_0 && ControllerPatcher::isControllerConnectedAndActive(UController_Type_Pro1)) ||
+         (chan == WPAD_CHAN_1 && ControllerPatcher::isControllerConnectedAndActive(UController_Type_Pro2)) ||
+         (chan == WPAD_CHAN_2 && ControllerPatcher::isControllerConnectedAndActive(UController_Type_Pro3)) ||
+         (chan == WPAD_CHAN_3 && ControllerPatcher::isControllerConnectedAndActive(UController_Type_Pro4)))) {
+        if (ControllerPatcher::setProControllerDataFromHID((void *) data, chan) == CONTROLLER_PATCHER_ERROR_NONE) {
+            return 1;
+        }
+    }
+    return real_KPADRead(chan, data, size);
+}
+
+DECL_FUNCTION(int32_t, KPADReadEx, KPADChan chan, KPADStatus *data, uint32_t size, KPADError *error) {
+    if (gConfigMenuOpen) {
+        return real_KPADReadEx(chan, data, size, error);
+    }
+    if (data != nullptr && size > 0 &&
+        ((chan == WPAD_CHAN_0 && ControllerPatcher::isControllerConnectedAndActive(UController_Type_Pro1)) ||
+         (chan == WPAD_CHAN_1 && ControllerPatcher::isControllerConnectedAndActive(UController_Type_Pro2)) ||
+         (chan == WPAD_CHAN_2 && ControllerPatcher::isControllerConnectedAndActive(UController_Type_Pro3)) ||
+         (chan == WPAD_CHAN_3 && ControllerPatcher::isControllerConnectedAndActive(UController_Type_Pro4)))) {
+        if (ControllerPatcher::setProControllerDataFromHID((void *) data, chan) == CONTROLLER_PATCHER_ERROR_NONE) {
+            if (error) {
+                *error = KPAD_ERROR_OK;
+            }
+            return 1;
+        }
+    }
+    return real_KPADReadEx(chan, data, size, error);
+}
+
 DECL_FUNCTION(void, WPADControlMotor, WPADChan chan, uint32_t status) {
     if (gConfigMenuOpen) {
         real_WPADControlMotor(chan, status);
@@ -203,6 +239,8 @@ WUPS_MUST_REPLACE(KPADSetConnectCallback, WUPS_LOADER_LIBRARY_PADSCORE, KPADSetC
 WUPS_MUST_REPLACE(WPADSetConnectCallback, WUPS_LOADER_LIBRARY_PADSCORE, WPADSetConnectCallback);
 WUPS_MUST_REPLACE(WPADSetExtensionCallback, WUPS_LOADER_LIBRARY_PADSCORE, WPADSetExtensionCallback);
 WUPS_MUST_REPLACE(WPADRead, WUPS_LOADER_LIBRARY_PADSCORE, WPADRead);
+WUPS_MUST_REPLACE(KPADRead, WUPS_LOADER_LIBRARY_PADSCORE, KPADRead);
+WUPS_MUST_REPLACE(KPADReadEx, WUPS_LOADER_LIBRARY_PADSCORE, KPADReadEx);
 WUPS_MUST_REPLACE(WPADGetDataFormat, WUPS_LOADER_LIBRARY_PADSCORE, WPADGetDataFormat);
 WUPS_MUST_REPLACE(WPADSetDataFormat, WUPS_LOADER_LIBRARY_PADSCORE, WPADSetDataFormat);
 WUPS_MUST_REPLACE(WPADControlMotor, WUPS_LOADER_LIBRARY_PADSCORE, WPADControlMotor);

--- a/src/WUPSConfigItemPadMapping.cpp
+++ b/src/WUPSConfigItemPadMapping.cpp
@@ -18,7 +18,6 @@
 #include "WUPSConfigItemPadMapping.h"
 #include <controller_patcher/ControllerPatcher.hpp>
 #include <coreinit/debug.h>
-#include <wups/config_api.h>
 #include <padscore/wpad.h>
 #include <stdio.h>
 #include <string.h>
@@ -26,6 +25,7 @@
 #include <utils/logger.h>
 #include <vector>
 #include <vpad/input.h>
+#include <wups/config_api.h>
 
 // At this point the VPADRead function is already patched. But we want to use the original function (note: this could be patched by a different plugin)
 typedef int32_t (*VPADReadFunction)(VPADChan chan, VPADStatus *buffer, uint32_t buffer_size, VPADReadError *error);

--- a/src/WUPSConfigItemPadMapping.cpp
+++ b/src/WUPSConfigItemPadMapping.cpp
@@ -18,6 +18,7 @@
 #include "WUPSConfigItemPadMapping.h"
 #include <controller_patcher/ControllerPatcher.hpp>
 #include <coreinit/debug.h>
+#include <wups/config_api.h>
 #include <padscore/wpad.h>
 #include <stdio.h>
 #include <string.h>
@@ -218,7 +219,7 @@ extern "C" bool WUPSConfigItemPadMapping_AddToCategory(WUPSConfigCategoryHandle 
     item->state          = CONFIG_ITEM_PAD_MAPPING_STATE_NONE;
     memset(&item->mappedPadInfo, 0, sizeof(item->mappedPadInfo));
 
-    WUPSConfigCallbacks_t callbacks = {
+    WUPSConfigAPIItemCallbacksV1 callbacks = {
             .getCurrentValueDisplay         = &WUPSConfigItemPadMapping_getCurrentValueDisplay,
             .getCurrentValueSelectedDisplay = &WUPSConfigItemPadMapping_getCurrentValueDisplaySelected,
             .onSelected                     = &WUPSConfigItemPadMapping_onSelected,
@@ -228,12 +229,22 @@ extern "C" bool WUPSConfigItemPadMapping_AddToCategory(WUPSConfigCategoryHandle 
             .onButtonPressed                = &WUPSConfigItemPadMapping_onButtonPressed,
             .onDelete                       = &WUPSConfigItemPadMapping_onDelete};
 
-    if (WUPSConfigItem_Create(&item->handle, configID, displayName, callbacks, item) < 0) {
+    WUPSConfigAPIItemOptionsV1 options = {
+            .configId    = configID,
+            .displayName = displayName,
+            .context     = item,
+            .callbacks   = callbacks};
+
+    WUPSConfigAPICreateItemOptions itemOptions;
+    itemOptions.version = WUPS_API_ITEM_OPTION_VERSION_V1;
+    itemOptions.data.v1 = options;
+
+    if (WUPSConfigAPI_Item_CreateEx(itemOptions, &item->handle) != WUPSCONFIG_API_RESULT_SUCCESS) {
         free(item);
         return false;
     }
 
-    if (WUPSConfigCategory_AddItem(cat, item->handle) < 0) {
+    if (WUPSConfigAPI_Category_AddItem(cat, item->handle) != WUPSCONFIG_API_RESULT_SUCCESS) {
         return false;
     }
     return true;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -37,7 +37,7 @@ WUPS_USE_STORAGE("hid_to_vpad");
 extern bool runNetworkClient;
 
 #define SD_PATH                          "fs:/vol/external01"
-#define WIIU_PATH                         "/wiiu"
+#define WIIU_PATH                        "/wiiu"
 #define DEFAULT_CONTROLLER_PATCHER_PATCH SD_PATH WIIU_PATH "/controller"
 
 void ConfigLoad();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,21 +16,25 @@
  ****************************************************************************/
 
 #include <wups.h>
+#include <wups/config_api.h>
 
 #include <controller_patcher/ControllerPatcher.hpp>
 #include <cstring>
 #include <utils/logger.h>
 
+WUPSConfigAPICallbackStatus configMenuOpenedCallback(WUPSConfigCategoryHandle root);
+void configMenuClosedCallback();
+
 WUPS_PLUGIN_NAME("HID to VPAD");
 WUPS_PLUGIN_DESCRIPTION("Enables HID devices as controllers on your Wii U");
-WUPS_PLUGIN_VERSION("0.1.1-alpha");
+WUPS_PLUGIN_VERSION("0.2-alpha");
 WUPS_PLUGIN_AUTHOR("Maschell");
 WUPS_PLUGIN_LICENSE("GPL");
 
 WUPS_USE_WUT_DEVOPTAB();
 WUPS_USE_STORAGE("hid_to_vpad");
 
-extern int32_t runNetworkClient;
+extern bool runNetworkClient;
 
 #define SD_PATH                          "fs:/vol/external01"
 #define WIIU_PATH                         "/wiiu"
@@ -56,6 +60,7 @@ ON_APPLICATION_START() {
 
 INITIALIZE_PLUGIN() {
     WHBLogUdpInit();
+    WUPSConfigAPI_Init({.name = "HID to VPAD"}, configMenuOpenedCallback, configMenuClosedCallback);
 }
 
 DEINITIALIZE_PLUGIN() {

--- a/src/utils/logger.h
+++ b/src/utils/logger.h
@@ -1,13 +1,9 @@
 #pragma once
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <cstring>
 #include <whb/log.h>
-#include <whb/log_udp.h>
 #include <whb/log_cafe.h>
+#include <whb/log_udp.h>
 
 #define __FILENAME_X__ (strrchr(__FILE__, '\\') ? strrchr(__FILE__, '\\') + 1 : __FILE__)
 #define __FILENAME__   (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILENAME_X__)
@@ -21,7 +17,3 @@ extern "C" {
     do {                                                                                         \
         WHBLogWritef("[%23s]%30s@L%04d: " FMT "", __FILENAME__, __FUNCTION__, __LINE__, ##ARGS); \
     } while (0);
-
-#ifdef __cplusplus
-}
-#endif


### PR DESCRIPTION
# Purpose
- Fix issue of some HID devices resetting stick input to centre if HID data was not changing, when mapped as a Pro Controller.
- Update to build under WUPS 0.9.1, to avoid plugin instability warning.

# Changes
- Add KPADRead and KPADReadEx patches so HID stick data reaches games that call either variant; previously only WPADRead was intercepted, causing stick input to read as zero when no HID change occurred in KPAD mode.
- Migrate storage API from WUPS_OpenStorage/WUPS_GetBool/WUPS_GetString etc. to WUPSStorageAPI namespace (GetOrStoreDefault, Store, SaveStorage) and WUPSStorageAPI_GetString/StoreString C API. Guard each string read with buffer[0]='\0' before the call and buffer[0]!='\0' after to defend against WUPSStorageAPI_GetString returning success without writing for missing keys, which caused a single pro controller mapping to bleed into other slots.
- Replace WUPS_GET_CONFIG/WUPS_CONFIG_CLOSED hook macros (removed in 0.9.1) with WUPSConfigAPI_Init callback registration in INITIALIZE_PLUGIN.
- Replace WUPSConfigCallbacks_t/WUPSConfigItem_Create/WUPSConfigCategory_AddItem with WUPSConfigAPIItemCallbacksV1/WUPSConfigAPI_Item_CreateEx/ WUPSConfigAPI_Category_AddItem in WUPSConfigItemPadMapping.
- Bump version to 0.2.

## Build
- Compiled successfully using the Docker image from [WiiUPluginLoaderBackend](https://github.com/wiiu-env/WiiUPluginLoaderBackend/blob/main/Dockerfile), based on `ghcr.io/wiiu-env/devkitppc:20260225`
- Requires updated [_controller_patcher_](https://github.com/Maschell/controller_patcher/pull/44) with changes for WUPS 0.9.1

## Download
- Download the compiled _hid_to_vpad_ binary [here at Gbatemp](https://gbatemp.net/threads/hid-to-vpad.424127/post-10862167).